### PR TITLE
Update REGEX_RAW_dpaste

### DIFF
--- a/wgetpaste
+++ b/wgetpaste
@@ -561,7 +561,8 @@ geturl() {
 		sed -n -e "${!regex}" <<< "$*"
 	else
 		[[ needstdout = $1 ]] && return 1
-		sed -n -e 's|^.*Location: \(https\{0,1\}://[^ ]*\).*$|\1|p' <<< "$*"
+		svc_url=URL_$SERVICE
+		sed -n -e "s|^.*Location: \\(${!svc_url}[^ ]*\\).*$|\\1|p" <<< "$*"
 	fi | tail -n1
 }
 

--- a/wgetpaste
+++ b/wgetpaste
@@ -55,7 +55,7 @@ Ruby Rhtml Sql Xml"
 EXPIRATIONS_dpaste="30%days 30%days%after%last%view"
 EXPIRATION_VALUES_dpaste="off on"
 POST_dpaste="submit=Paste+it poster title language hold % content"
-REGEX_RAW_dpaste='s|^\(http://[^/]*/\)[^0-9]*\([0-9]*/\)$|\1\2plain/|'
+REGEX_RAW_dpaste='s|^http://[^/]*/[0-9A-Za-z]*$|\0.txt|'
 # gists
 LANGUAGES_gists="ActionScript Ada Apex AppleScript Arc Arduino ASP Assembly
 Augeas AutoHotkey Batchfile Befunge BlitzMax Boo Brainfuck Bro C C# C++


### PR DESCRIPTION
Update REGEX_RAW_dpaste

The URL returned when running `wgetpaste -r -dpaste ...` returns the wrong URL for the raw post.  This change to the regex fixes that error.