### PR TITLE
Fallback location regex confusion fix

### DIFF
--- a/wgetpaste
+++ b/wgetpaste
@@ -561,7 +561,8 @@ geturl() {
 		sed -n -e "${!regex}" <<< "$*"
 	else
 		[[ needstdout = $1 ]] && return 1
-		sed -n -e 's|^.*Location: \(https\{0,1\}://[^ ]*\).*$|\1|p' <<< "$*"
+		svc_url=URL_$SERVICE
+		sed -n -e "s|^.*Location: \\(${!svc_url}[^ ]*\\).*$|\\1|p" <<< "$*"
 	fi | tail -n1
 }
 


### PR DESCRIPTION
The fallback location regex can get confused if the input data contains
URLs, and the confusion will cause wgetpaste to print the wrong link to
the paste.

Updated the regex so it finds the last URL that contains the service
URL.  wgetpaste can still get confused after this commit, but this
commit should reduce the likelihood.

Signed-off-by: Nicholas Vinson <nvinson234@gmail.com>
Fixes issue #10 