### PR TITLE
Add missing dpaste escape functions

### DIFF
--- a/wgetpaste
+++ b/wgetpaste
@@ -110,6 +110,8 @@ Python Python%Interactive/Traceback Ruby Ruby%HTML%(ERB) SQL XML"
 LANGUAGE_VALUES_dpaste="% Apache Bash Css Diff DjangoTemplate Haskell JScript Python PythonConsole \
 Ruby Rhtml Sql Xml"
 EXPIRATIONS_dpaste=$(printf "%s " {1..365})
+escape_description_dpaste() { echo "$*"; }
+escape_input_dpaste() { echo "$*"; }
 POST_dpaste() {
 	local title="${2}"
 	local syntax="${3}"


### PR DESCRIPTION
escape_description_dpaste() and escape_input_dpaste() are missing which
causes the default escape function to be used.  This results in mangled
pastes.

Fixes: #22