### PR TITLE
Do not interpret content when posting to dpaste

### DIFF
--- a/wgetpaste
+++ b/wgetpaste
@@ -133,8 +133,8 @@ POST_dpaste() {
 	echo -e "--$boundary\r"
 	echo -e "Content-Disposition: form-data; name=\"content\"\r"
 	echo -e "\r"
-	echo -e "${content}\r"
-	echo -e "--${boundary}--\r"
+	echo -n "${content}"
+	echo -e "\r\n--${boundary}--\r"
 	ADDITIONAL_HEADERS_dpaste=("Content-Type: multipart/form-data; boundary=${boundary}")
 }
 REGEX_RAW_dpaste='s|^http.*|\0.txt|'


### PR DESCRIPTION
'echo -e' is used to prepare data for dpaste.  However if
`echo -e "${content}"` is used, the content gets interpreted as well.
This results in constructs such as '\0' getting misinterpreted as the
byte 0x00.  As a result, the interperted context can result in output
not compatible with dpaste.

fixes bug #25