### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -5,14 +5,14 @@ jobs:
     name: 'Run test/test.sh'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: test/test.sh
         shell: bash
   run-test-ansi:
     name: 'Run test/test_ansi.sh'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Install ansifilter'
         run: |
           sudo apt-get update


### PR DESCRIPTION
Avoids a warning about Node.js 12 actions being deprecated.