### PR TITLE
Add the quiet flag

### DIFF
--- a/_wgetpaste
+++ b/_wgetpaste
@@ -50,6 +50,7 @@ _arguments -s : \
   '(--xclippaste -C)'{--xclippaste,-C}'[write resulting url to the X clipboard selection buffer]' \
   '(--raw -r)'{--raw,-r}'[show url for the raw paste]' \
   '(--tee -t)'{--tee,-t}'[use tee to show what is being pasted]' \
+  '(--quiet -q)'{--quiet,-q}'[stdout only the url]' \
   '(--verbose -v)'{--verbose,-v}'[show wget stderr output if no url is received]' \
   '--debug[be very verbose]' \
   '(--help -h)'{--help,-h}'[show help and exit]' \

--- a/wgetpaste
+++ b/wgetpaste
@@ -559,7 +559,7 @@ Options:
 
     -r, --raw                     show url for the raw paste (no syntax highlighting or html)
     -t, --tee                     use tee to show what is being pasted
-	-q, --quiet                   stdout only the url
+    -q, --quiet                   stdout only the url
     -v, --verbose                 show wget stderr output if no url is received
         --completions             emit output suitable for shell completions (only affects --list-*)
         --debug                   be *very* verbose (implies -v)

--- a/wgetpaste
+++ b/wgetpaste
@@ -559,6 +559,7 @@ Options:
 
     -r, --raw                     show url for the raw paste (no syntax highlighting or html)
     -t, --tee                     use tee to show what is being pasted
+	-q, --quiet                   stdout only the url
     -v, --verbose                 show wget stderr output if no url is received
         --completions             emit output suitable for shell completions (only affects --list-*)
         --debug                   be *very* verbose (implies -v)
@@ -657,7 +658,11 @@ showexpirations() {
 }
 
 showurl() {
-	echo -n "Your ${2}paste can be seen here: " >&2
+	if [[ $QUIET ]]; then
+		echo -n "" >&2
+	else
+		echo -n "Your ${2}paste can be seen here: " >&2
+	fi
 	echo "$1"
 	[[ $XPASTE ]] && x_paste "$1" primary
 	[[ $XCLIPPASTE ]] && x_paste "$1" clipboard
@@ -808,6 +813,9 @@ while [[ -n $1 ]]; do
 		;;
 		-N | --no-ansi )
 		NOANSI=0
+		;;
+		-q | --quiet)
+		QUIET=0
 		;;
 		-r | --raw )
 		RAW=0


### PR DESCRIPTION
Adds a new option that will only return the URL and nothing else to stdout on a successful run. 

This has a few uses:
* Enables piping the output URL into other programs
* Much easier to copy from most term emulators (double click the line, instead of carefully selecting only the link)

I made the --quiet flag only have an affect on a successful run, but if it would make more sense for it to also output nothing on failure, I could do that too.