### PR TITLE
fix gists raw url

### DIFF
--- a/wgetpaste
+++ b/wgetpaste
@@ -171,7 +171,7 @@ rb rs sage sass scala scm sci scss self sh st tpl sql sml sc tcl tcsh tea tex
 textile t twig vala v vhd vim vb xml xq xs yml auto"
 DEFAULT_LANGUAGE_gists="Auto"
 REGEX_URL_gists='s|^.*"html_url": "\([^"]\+gist[^"]\+\)".*$|\1|p'
-REGEX_RAW_gists='s|^\(https://gist.github.com\)\(/.*\)$|\1/raw\2|'
+REGEX_RAW_gists='s|^\(https://gist.github.com\)\(/.*\)$|\1\2/raw|'
 escape_description_gists() { sed -e 's|"|\\"|g' -e 's|\x1b|\\u001b|g' -e 's|\r||g' <<< "$*"; }
 escape_input_gists() { sed -e 's|\\|\\\\|g' -e 's|\x1b|\\u001b|g' -e 's|\r||g' -e 's|\t|\\t|g' -e 's|"|\\"|g' -e 's|$|\\n|' <<< "$*" | tr -d '\n'; }
 POST_gists() {


### PR DESCRIPTION
Existing raw pattern: `https://gist.github.com/raw/<organization_label>/<gist_id>` is currently http 404
New raw pattern looks to be: `https://gist.github.com/<organization_label>/<gist_id>/raw` which is http 200